### PR TITLE
Fedora uses dnf now.

### DIFF
--- a/installation/index.html
+++ b/installation/index.html
@@ -40,7 +40,7 @@ devtools::install_github('IRkernel/IRkernel')
 				<h5>Ubuntu and Debian</h5>
 				<pre class="bash"><code>sudo apt-get install libzmq3-dev</code></pre>
 				<h5>Fedora</h5>
-				<pre class="bash"><code>sudo yum install czmq-devel</code></pre>
+				<pre class="bash"><code>sudo dnf install czmq-devel</code></pre>
 				<h5>Arch Linux</h5>
 				<pre class="bash"><code>sudo pacman -S zeromq</code></pre>
 			</div>


### PR DESCRIPTION
`yum` is no longer used in any supported release.