### PR TITLE
Add missing dependencies in Linux instructions

### DIFF
--- a/installation/index.html
+++ b/installation/index.html
@@ -42,8 +42,8 @@ devtools::install_github('IRkernel/IRkernel')
 				<h5>Fedora</h5>
 				<pre class="bash"><code>sudo dnf install czmq-devel libcurl-devel openssl-devel</code></pre>
 				<h5>Arch Linux</h5>
-				<pre class="bash"><code>sudo pacman -S zeromq</code></pre>
-				<pre class="bash"><code>sudo yaourt -S libcurl-openssl-1.0</code></pre>
+				<pre class="bash"><code>sudo pacman -S zeromq
+sudo yaourt -S libcurl-openssl-1.0</code></pre>
 			</div>
 			<div class="card-panel mdl-tabs__panel" id=os-x-panel>
 				<h5>Homebrew</h5>

--- a/installation/index.html
+++ b/installation/index.html
@@ -42,8 +42,7 @@ devtools::install_github('IRkernel/IRkernel')
 				<h5>Fedora</h5>
 				<pre class="bash"><code>sudo dnf install czmq-devel libcurl-devel openssl-devel</code></pre>
 				<h5>Arch Linux</h5>
-				<pre class="bash"><code>sudo pacman -S zeromq
-sudo yaourt -S libcurl-openssl-1.0</code></pre>
+				<pre class="bash"><code>sudo pacman -S zeromq curl openssl</code></pre>
 			</div>
 			<div class="card-panel mdl-tabs__panel" id=os-x-panel>
 				<h5>Homebrew</h5>

--- a/installation/index.html
+++ b/installation/index.html
@@ -38,11 +38,11 @@ devtools::install_github('IRkernel/IRkernel')
 			</div>
 			<div class="card-panel mdl-tabs__panel" id=linux-panel>
 				<h5>Ubuntu and Debian</h5>
-				<pre class="bash"><code>sudo apt-get install libzmq3-dev</code></pre>
+				<pre class="bash"><code>sudo apt-get install libzmq3-dev libcurl-openssl1.0-dev libssl-dev</code></pre>
 				<h5>Fedora</h5>
-				<pre class="bash"><code>sudo dnf install czmq-devel</code></pre>
+				<pre class="bash"><code>sudo dnf install czmq-devel libcurl-devel openssl-devel</code></pre>
 				<h5>Arch Linux</h5>
-				<pre class="bash"><code>sudo pacman -S zeromq</code></pre>
+				<pre class="bash"><code>sudo pacman -S zeromq libcurl-openssl-1.0</code></pre>
 			</div>
 			<div class="card-panel mdl-tabs__panel" id=os-x-panel>
 				<h5>Homebrew</h5>

--- a/installation/index.html
+++ b/installation/index.html
@@ -42,7 +42,8 @@ devtools::install_github('IRkernel/IRkernel')
 				<h5>Fedora</h5>
 				<pre class="bash"><code>sudo dnf install czmq-devel libcurl-devel openssl-devel</code></pre>
 				<h5>Arch Linux</h5>
-				<pre class="bash"><code>sudo pacman -S zeromq libcurl-openssl-1.0</code></pre>
+				<pre class="bash"><code>sudo pacman -S zeromq</code></pre>
+				<pre class="bash"><code>sudo yaourt -S libcurl-openssl-1.0</code></pre>
 			</div>
 			<div class="card-panel mdl-tabs__panel" id=os-x-panel>
 				<h5>Homebrew</h5>


### PR DESCRIPTION
In the "installing from source" instructions for Linux, a few
development package dependencies are missing.  They are needed to
install `devtools`, namely: libcurl, and ssl.  There might be
others.

I can only verify the package names for Fedora, I have updated
the Ubuntu and Arch instructions based on the following:

- Ubuntu
  https://packages.ubuntu.com/bionic/libcurl-openssl1.0-dev
  https://packages.ubuntu.com/bionic/libssl-dev

- Arch (openssl is pulled in as a dependency)
  https://aur.archlinux.org/packages/libcurl-openssl-1.0/